### PR TITLE
Optimise the vertex position displacement shader

### DIFF
--- a/GODOT - HexDisplacement/Displacement/VDisplacementPos.shader
+++ b/GODOT - HexDisplacement/Displacement/VDisplacementPos.shader
@@ -2,7 +2,6 @@ shader_type spatial;
 
 uniform vec2 uFirstCenter;
 uniform vec2 uCentersOffset;
-uniform vec2 uGridSize;
 
 uniform vec2 uPosCenter;
 uniform float uRadius;
@@ -11,21 +10,28 @@ uniform float uOffsetFactor;
 uniform sampler2D hexTexture;
 
 void vertex(){
-	float centerToUse = -1.0;
-	float closestCenterDistance = 1000000.0;
+	float closestColumn = round(( VERTEX.x - uFirstCenter.x) / uCentersOffset.x);
+	float closestRow    = round((-VERTEX.z - uFirstCenter.y) / uCentersOffset.y);
 	
-	for(int n = 0; n < (int(uGridSize.x) * int(uGridSize.y)); n++){
-		vec2 calculatedCenter = vec2(uFirstCenter.x + (uCentersOffset.x * mod(float(n), uGridSize.x)),
-			uFirstCenter.y + (uCentersOffset.y * mod(float(n), 2.0)) + (floor(float(n) / uGridSize.x) * (2.0 * uCentersOffset.y)));
-			
-		if (distance(vec2(VERTEX.x, -VERTEX.z), vec2(calculatedCenter.x, calculatedCenter.y)) < closestCenterDistance){
-			centerToUse = float(n);
-			closestCenterDistance = distance(vec2(VERTEX.x, -VERTEX.z), vec2(calculatedCenter.x, calculatedCenter.y));
-		}
+	vec2 closestGridCenter = vec2(
+		uFirstCenter.x + (closestColumn * uCentersOffset.x),
+		uFirstCenter.y + (closestRow    * uCentersOffset.y)
+	);
+
+	if (-VERTEX.z > closestGridCenter.y) {
+		closestRow    += 1.0;
+	} else if (-VERTEX.z < closestGridCenter.y) {
+		closestRow    -= 1.0;
+	} else if ( VERTEX.x < closestGridCenter.x) {
+		closestColumn -= 1.0;
+	} else if ( VERTEX.x > closestGridCenter.x) {
+		closestColumn += 1.0;
 	}
 	
-	vec2 centerToUseVec2 = vec2(uFirstCenter.x + (uCentersOffset.x * mod(centerToUse, uGridSize.x)),
-		uFirstCenter.y + (uCentersOffset.y * mod(centerToUse, 2.0)) + (floor(centerToUse / uGridSize.x) * (2.0 * uCentersOffset.y)));
+	vec2 centerToUseVec2 = vec2(
+		uFirstCenter.x + (closestColumn * uCentersOffset.x),
+		uFirstCenter.y + (closestRow    * uCentersOffset.y)
+	);
 	
 	VERTEX.y += clamp((clamp(distance(centerToUseVec2, uPosCenter), 0.0, uRadius) / uRadius) * uOffsetFactor, uOffsetFactor * 0.5, uOffsetFactor) - uOffsetFactor;
 }

--- a/GODOT - HexDisplacement/Displacement/VDisplacementPosM.tres
+++ b/GODOT - HexDisplacement/Displacement/VDisplacementPosM.tres
@@ -7,7 +7,6 @@
 shader = ExtResource( 2 )
 shader_param/uFirstCenter = Vector2( 0.28, 0.25 )
 shader_param/uCentersOffset = Vector2( 0.43, 0.25 )
-shader_param/uGridSize = Vector2( 16, 10 )
 shader_param/uPosCenter = Vector2( 0, 0 )
 shader_param/uRadius = 3.0
 shader_param/uOffsetFactor = 5.0


### PR DESCRIPTION
Hey, 

First off thank you for your great tutorials & demo's, they're interesting and I've found them very helpful.

I've been experimenting with your displacement shader, and I wondered if the for-loop could be avoided. I don't know whether it would be a problem or not but I imagined that as the honeycomb got larger, having every vertex loop over every hexagon might run into performance issues. (I think it's O(n^2) relative to the number of hexagons?)

I've had a go at this anyway, let me know what you think!

Thanks,
Jak